### PR TITLE
allow custom makeNewUrlFn

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,11 +61,20 @@ module.exports = (opts = {}) => {
       const rev = revHash(await readFile(fullpath));
       const name = basename(fullpath, ext);
       const filename = `${name}-${rev}${ext}`;
+      const newUrl = makeNewUrlFn({
+        staticPath,
+        filename,
+        fullpath,
+        name,
+        rev,
+      });
+
+      console.log(`fullpath ${fullpath} will become ${newUrl}`);
 
       return {
         fullpath,
         filename,
-        url: makeNewUrlFn({ staticPath, filename, fullpath, name, rev }),
+        url: newUrl,
       };
     };
 
@@ -134,8 +143,22 @@ module.exports = (opts = {}) => {
     await ForEach(
       UniqBy(assets.filter(Boolean), 'filename'),
       async ({ fullpath, filename }) => {
-        return Cp(fullpath, join(destinationDir, filename));
+        const destPath = join(destinationDir, filename);
+        console.log(`Will copy from ${fullpath} to ${destPath}`);
+        try {
+          await Cp(fullpath, destPath);
+        } catch (error) {
+          console.log(`Error on ${fullpath}`);
+          console.log(error);
+        }
+
+        if (await exists(fullpath)) {
+          console.log(`${fullpath} does exist`);
+        } else {
+          console.log(`${fullpath} does not exist`);
+        }
       },
+      {},
     );
 
     return newTree;

--- a/index.js
+++ b/index.js
@@ -28,8 +28,17 @@ const map = async (tree, iteratee) => {
   return preorder(tree, null, null);
 };
 
+function defaultMakeNewUrlFn({ filename, staticPath }) {
+  return resolve('/', staticPath, filename);
+}
+
 module.exports = (opts = {}) => {
-  const { destinationDir, staticPath = '/', ignoreFileExtensions = [] } = opts;
+  const {
+    destinationDir,
+    staticPath = '/',
+    ignoreFileExtensions = [],
+    makeNewUrlFn = defaultMakeNewUrlFn,
+  } = opts;
 
   return async (tree, { cwd, path }) => {
     const assets = [];
@@ -56,7 +65,7 @@ module.exports = (opts = {}) => {
       return {
         fullpath,
         filename,
-        url: resolve('/', staticPath, filename),
+        url: makeNewUrlFn({ staticPath, filename, fullpath, name, rev }),
       };
     };
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "scripts": {
     "eslint": "eslint . --ext .js",
-    "fmt": "prettier --config package.json --write '**/*'",
-    "test": "NODE_ENV=test c8 -r lcovonly -r text ava --timeout 9999 --serial"
+    "fmt": "cross-env prettier --config package.json --write '**/*'",
+    "test": "cross-env NODE_ENV=test c8 -r lcovonly -r text ava --timeout 9999 --serial"
   },
   "dependencies": {
     "apr-for-each": "^3.0.3",
@@ -34,6 +34,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "ava": "^3.13.0",
     "c8": "^7.3.5",
+    "cross-env": "^7.0.2",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-config-xo-space": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cp-file": "^9.0.0",
     "is-relative-url": "^3.0.0",
     "lodash.uniqby": "^4.7.0",
+    "mz": "^2.7.0",
     "rev-hash": "^3.0.0"
   },
   "devDependencies": {
@@ -38,7 +39,6 @@
     "eslint-config-xo-space": "^0.25.0",
     "husky": "^4.3.0",
     "lint-staged": "^10.5.1",
-    "mz": "^2.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
     "remark": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,6 +1408,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-env@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "cross-env@npm:7.0.2"
+  dependencies:
+    cross-spawn: ^7.0.1
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 624d638db3b4b6b221f32238aeb6785b865365bf41154f01d46a23b6d78f807ca5588a3b32e9af5f17384b866fed3752d0e3ecf8c4a8cfca2935d363d27ba058
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^6.0.5":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
@@ -1421,7 +1433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -4618,6 +4630,7 @@ fsevents@~2.1.2:
     c8: ^7.3.5
     cheerio: ^1.0.0-rc.3
     cp-file: ^9.0.0
+    cross-env: ^7.0.2
     eslint: ^7.13.0
     eslint-config-prettier: ^6.15.0
     eslint-config-xo-space: ^0.25.0


### PR DESCRIPTION
Hi !

Thanks for this plugin !

I've tried using it in project where I use Next.js on a Windows machine and I had a few adjustments to make.

Basically, I think it could be good to offer users the option to control the way they create the new URLs to use for their files. 

Based on this discussion, I think other people might be interested: https://github.com/vercel/next.js/discussions/12663

Here is how I'm using this option in my project:

```javascript
// fichier next.config.js
const path = require('path');

const copyLinkedFiles = require('remark-copy-linked-files'); // version locale modifiée

const MD_MEDIA_COPIES = 'md-media-copies';
const destinationDir = path.join(__dirname, 'public', MD_MEDIA_COPIES);


const makeNewUrlFn = ({filename, fullpath}) => {
  const splitFullPath = fullpath.split(path.sep);
  const lastPathPart = splitFullPath.pop();
  if (lastPathPart.match('index')) splitFullPath.pop();
  const relativePath = path.relative(splitFullPath.join(path.sep), path.join(__dirname, 'pages'));
  return path.join(relativePath, MD_MEDIA_COPIES, filename).replace(/\\/g, '/');
}

const withMDX = require('@next/mdx')({
  extension: /\.mdx?$/,
  options: {
    remarkPlugins: [
      [copyLinkedFiles, { destinationDir, makeNewUrlFn }]
    ]
  }
})
module.exports = withMDX({
  pageExtensions: ['js', 'jsx', 'mdx', 'md'],
})
```

Let me know if you think it's interesting and if some things should be changed.