### PR TITLE
Add option to skip copying

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = (opts = {}) => {
     ignoreFileExtensions = [],
     buildUrl = defaultUrlBuilder,
     selectors: customSelectors = [],
+    transformAsset,
   } = opts;
 
   return async (tree, { cwd, path }) => {
@@ -124,9 +125,13 @@ module.exports = (opts = {}) => {
         });
       },
       url: async (node) => {
-        const asset = await handleUrl(node.url);
+        let asset = await handleUrl(node.url);
+        if (transformAsset) {
+          asset = transformAsset(asset);
+        }
 
         assets.push(asset);
+
         return Object.assign(node, {
           url: asset ? asset.url || node.url : node.url,
         });

--- a/package.json
+++ b/package.json
@@ -60,12 +60,6 @@
     "unified": "^9.2.0",
     "vfile": "^4.2.0"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
-  },
   "lint-staged": {
     "*.js": [
       "eslint --fix",


### PR DESCRIPTION
When using Next.js on Vercel the file system is locked after build phases.

So essentially I want to run the plugin in a copy phase during build time.
Then during a separate phase of building staticProps want to skip the copy and just replacement of the URLs which will still just be the same hash as was copied over.

If you feel like this is wrong or whatever I am happy to keep this as a separate fork and just use as is but figured I'd contribute back.