### PR TITLE
Add a sourceDir option to support handling MDX files loaded from disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,30 @@ And writes the following files:
 0 directories, 7 files
 ```
 
+## Configuration
+
+This plugin takes the following configuration options:
+
+### `destinationDir`
+
+Path to the directory where the files should be copied.
+This option is mandatory.
+
+### `sourceDir`
+
+Path to the directory where the files should be copied from.
+Use this if the MDX file you are loading is not the one calling this plugin.
+
+Default is the current working directory.
+
+### `staticPath`
+
+Prefix to use in the `src` attribute. Set this if the files are copied in a 
+location that is is not hosted under `/`.
+
+Default is `/`.
+
+
 ## license
 
 BSD-3-Clause

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const defaultUrlBuilder = ({ filename, staticPath }) => {
 module.exports = (opts = {}) => {
   const {
     destinationDir,
+    sourceDir=false,
     staticPath = '/',
     ignoreFileExtensions = [],
     buildUrl = defaultUrlBuilder,
@@ -59,7 +60,7 @@ module.exports = (opts = {}) => {
       }
 
       const fullpath = resolve(
-        cwd,
+        sourceDir ? sourceDir : cwd,
         path ? dirname(path) : '',
         platformNormalizedUrl,
       );


### PR DESCRIPTION
Hi there :wave: 

Thanks for this plugin. I wanted to use it for a NextJS site I am working on, but it turned out it didn't work.

That's because I have one dynamic page in NextJS that will load the markdown/mdx file from a markdown folder based on the the path that's requested.
In other words, the source images and files to be copied are not in the current working directory, but elsewhere.

So, I've added the `sourceDir` option which defaults to `false`. If `sourceDir` is set, it will use it to contruct the full path to the source file(s). If not, it will use `cwd` just as without this change.

I've also updated the README file to document this new `sourceDir` option as well as the `targetDir` and `staticPath` options since I felt it could save people the trouble of looking through the source code.

I hope you'll find this contribution useful and would be willing to merge it so I don't have to maintain this myself :wink: 
That being said, I acknowledge that you are the boss and I respect whatever choice you make.

Happy Xmas :christmas_tree: 
joost